### PR TITLE
docs: Add contributing guide and AI assistant documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+Guidelines for AI coding assistants (Copilot, Cursor, Cody, Aider, etc.) working on this repository.
+
+## Contributing Workflow
+
+**All contributions must follow [CONTRIBUTING.md](CONTRIBUTING.md).** This applies to AI-assisted work.
+
+The required workflow:
+1. **Open an issue first** - Discuss the proposed change before writing code
+2. **Fork the repository** - External contributors work from forks
+3. **Create a feature branch** - Branch from `main` with a descriptive name
+4. **Make changes and test** - Follow the guidelines in CONTRIBUTING.md
+5. **Create a Pull Request** - Reference the issue number
+
+Do not push directly to `main`. All changes go through pull requests.
+
+## Project Context
+
+This repository contains **infrastructure and deployment automation only**:
+- Makefile orchestration
+- Bash scripts in `scripts/`
+- OpenShift/Kubernetes manifests in `infra/`
+
+**No application code lives here.** Backend (FastAPI) and frontend (Next.js) are in separate repositories.
+
+## Key Files
+
+- `Makefile` - All commands route through here
+- `scripts/` - Bash automation (use `set -euo pipefail`)
+- `infra/<service>/openshift/` - Kubernetes manifests per service
+- `CLAUDE.md` - Detailed project documentation and design decisions
+
+## Commit Messages
+
+Use conventional commits in imperative mood:
+- `fix: Increase MongoDB timeout to 30s`
+- `feat: Add Redis deployment manifests`
+- `docs: Update troubleshooting section`
+
+## Testing
+
+Before submitting changes:
+```bash
+# Local development
+make setup-local && make dev && make status
+
+# OpenShift (if applicable)
+oc login <cluster> && make setup-openshift && make oc-status
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,118 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a **hackathon infrastructure toolkit** for the "Griot & Grits" project - an AI-powered platform for preservation of minority history. The repository contains deployment automation for both local container-based development and Red Hat OpenShift environments. **No application code lives here** - backend (FastAPI) and frontend (Next.js) source code is in separate repositories (`gng-backend`, `gng-web`).
+
+## Common Commands
+
+### Local Development
+
+```bash
+make setup-local          # One-time setup (clones repos, installs deps)
+make dev                  # Start everything (MongoDB + MinIO + Backend + Frontend)
+make start-services       # Start MongoDB + MinIO only
+make dev-backend          # Start FastAPI backend
+make dev-frontend         # Start Next.js frontend
+make status               # Check what's running
+make stop-services        # Stop services
+make clean-local          # Remove containers
+```
+
+### OpenShift Development
+
+```bash
+# Initial setup
+oc login <cluster-url>
+make setup-openshift                  # Creates gng-<username> namespace with MongoDB + MinIO
+make setup-openshift-with-code        # Same + deploys backend/frontend with hot-reload
+
+# View information
+make info                             # Shows URLs, credentials, connection details
+make oc-status                        # View all OpenShift resources
+make oc-logs-backend                  # Backend logs
+make oc-logs-frontend                 # Frontend logs
+
+# Code sync (after setup-openshift-with-code)
+make watch-backend                    # Start continuous backend sync (background)
+make watch-backend-logs               # View sync activity
+make watch-backend-stop               # Stop sync
+make sync                             # Manual sync (both backend + frontend)
+
+# Cleanup
+make cleanup-jobs                     # Clean completed OpenShift jobs
+make clean-openshift                  # Delete namespace + local config files
+```
+
+### Admin Commands (cluster-admin only)
+
+```bash
+make admin-import-images              # Pre-import container images
+make admin-create-namespaces FILE=users.txt   # Bulk namespace creation
+make admin-create-namespaces COUNT=60         # Create numbered namespaces
+```
+
+## Architecture
+
+```
+Frontend (Next.js)  →  Backend (FastAPI)
+    :3000                   :8000
+                               ↓
+                    ┌──────────┼──────────┐
+                    ↓          ↓          ↓
+                MongoDB    MinIO    Whisper (optional)
+                 :27017    :9000
+                Database  Storage  Transcription
+```
+
+### Repository Structure
+
+```
+rh-hackathon/
+├── Makefile                  # Main orchestration (all commands route through here)
+├── scripts/                  # Bash automation scripts
+│   ├── setup.sh              # Local dev environment setup
+│   ├── setup-openshift.sh    # OpenShift namespace + services setup
+│   ├── deploy-services.sh    # Deploy MongoDB + MinIO to OpenShift
+│   ├── deploy-code.sh        # Deploy backend + frontend with hot-reload
+│   ├── sync-code.sh          # Manual code sync to pods
+│   └── watch-backend.sh      # Continuous backend file watcher
+├── infra/                    # Kubernetes/OpenShift YAML manifests
+│   ├── mongodb/openshift/    # MongoDB deployment + init job
+│   ├── minio/openshift/      # MinIO deployment + init job
+│   ├── backend/openshift/    # FastAPI deployment + config
+│   ├── frontend/openshift/   # Next.js deployment
+│   └── whisper/              # Optional Whisper ASR service
+└── env-templates/            # Environment file templates for apps
+```
+
+## Key Design Decisions
+
+1. **No pre-built images**: Code is cloned directly in pod init containers, enabling hot-reload with `uvicorn --reload` and `next dev`
+
+2. **Namespace auto-detection**: `.openshift-config` file stores namespace/username; most commands auto-detect from this file
+
+3. **emptyDir volumes**: MongoDB/MinIO use emptyDir (data lost on pod restart) - acceptable for hackathon use, not production
+
+4. **Hardcoded credentials**:
+   - MongoDB: `admin` / `gngdevpass12`
+   - MinIO: `minioadmin` / `minioadmin`
+   - Bucket: `artifacts`
+
+5. **Per-user isolation**: Each participant gets personal namespace `gng-<username>` with RBAC isolation
+
+## Working with This Repository
+
+When modifying infrastructure:
+- **Add new services**: Create `infra/<service>/openshift/` directory with YAML manifests
+- **Change default configuration**: Edit relevant script in `scripts/`
+- **Adjust resource limits**: Edit CPU/memory in deployment YAML files
+- **Add Makefile targets**: Follow the existing pattern with `check-oc` dependency for OpenShift commands
+
+When troubleshooting:
+- Use `make info` to see all connection details
+- Check `make oc-status` for resource state
+- View logs with `make oc-logs-<service>`
+- Override namespace: `make <command> NAMESPACE=gng-custom`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,15 @@ rh-hackathon/
 
 5. **Per-user isolation**: Each participant gets personal namespace `gng-<username>` with RBAC isolation
 
+## Git Workflow
+
+This is an active hackathon project:
+
+- **Never push without explicit request** - always wait for user to ask
+- **Never push to main** - main is protected; all changes go through PRs
+- **Use feature branches** - create a branch when starting work (wait for user direction on branch name/timing)
+- **Commits are fine** - commit freely to track progress on branches
+
 ## Working with This Repository
 
 When modifying infrastructure:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,18 @@ This is an active hackathon project:
 - **Use feature branches** - create a branch when starting work (wait for user direction on branch name/timing)
 - **Commits are fine** - commit freely to track progress on branches
 
+## Contributing
+
+**Follow [CONTRIBUTING.md](CONTRIBUTING.md) for all contributions.** The workflow is:
+
+1. Open an issue first to discuss the change
+2. Fork the repository (if external contributor)
+3. Create a feature branch from `main`
+4. Make changes, test, and commit
+5. Push and create a Pull Request referencing the issue
+
+This applies to AI-assisted contributions as well. When helping with contributions, guide the user through this workflow.
+
 ## Working with This Repository
 
 When modifying infrastructure:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,16 +95,28 @@ make oc-status
 
 Write clear commit messages in imperative mood:
 
+```
+<type>: <subject line - what changed>
+
+<body - why it changed, context>
+
+<footer - issue references>
+```
+
+Example:
+
 ```bash
-# Good
 git commit -m "fix: Increase MongoDB connection timeout to 30s
 
 The default 10s timeout was insufficient for slow cluster starts.
-Fixes #42"
 
-# Bad
-git commit -m "fixed stuff"
+Fixes #42"
 ```
+
+**Commit message structure:**
+- **Subject line**: Short summary with conventional prefix (50 chars or less)
+- **Body**: Explanation of why the change was made (wrap at 72 chars)
+- **Footer**: Issue references go here, on their own line (`Fixes #42`, `Closes #42`, or `Refs #42`)
 
 Use conventional commit prefixes:
 - `fix:` - Bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to Griot & Grits Hackathon Toolkit
+
+Thank you for your interest in contributing! This document outlines the process for contributing to this repository.
+
+## Before You Start
+
+**This repository contains infrastructure and deployment automation only.** Application code lives in separate repositories:
+- Backend (FastAPI): `gng-backend`
+- Frontend (Next.js): `gng-web`
+
+If your contribution involves application code, please contribute to those repositories instead.
+
+## Contribution Workflow
+
+### 1. Open an Issue First
+
+Before starting work, open an issue to discuss your proposed change:
+
+- **Bug reports**: Describe the problem, steps to reproduce, and expected behavior
+- **Feature requests**: Explain the use case and proposed solution
+- **Infrastructure changes**: Describe what you want to change and why
+
+This helps avoid duplicate work and ensures your contribution aligns with project goals. Wait for feedback before proceeding.
+
+### 2. Fork the Repository
+
+Once your issue is acknowledged:
+
+```bash
+# Fork via GitHub UI, then clone your fork
+git clone https://github.com/<your-username>/rh-hackathon.git
+cd rh-hackathon
+
+# Add upstream remote
+git remote add upstream https://github.com/griot-and-grits/rh-hackathon.git
+```
+
+### 3. Create a Feature Branch
+
+Create a branch from `main` with a descriptive name:
+
+```bash
+git checkout main
+git pull upstream main
+git checkout -b fix/mongodb-connection-timeout
+# or: feat/add-redis-support
+# or: docs/improve-troubleshooting
+```
+
+Branch naming conventions:
+- `fix/` - Bug fixes
+- `feat/` - New features
+- `docs/` - Documentation updates
+- `refactor/` - Code refactoring
+
+### 4. Make Your Changes
+
+Follow these guidelines:
+
+**For scripts (`scripts/`):**
+- Use `#!/bin/bash` and `set -euo pipefail`
+- Add helpful comments for non-obvious logic
+- Test on both local and OpenShift environments if applicable
+
+**For OpenShift manifests (`infra/`):**
+- Follow existing directory structure: `infra/<service>/openshift/`
+- Use reasonable resource limits
+- Test deployments before submitting
+
+**For Makefile changes:**
+- Follow existing patterns (use `check-oc` dependency for OpenShift commands)
+- Add help text for new targets
+- Keep targets simple and composable
+
+**General:**
+- Keep commits focused and atomic
+- Write clear commit messages (see below)
+- Don't include unrelated changes
+
+### 5. Test Your Changes
+
+```bash
+# For local development changes
+make setup-local
+make dev
+make status
+
+# For OpenShift changes
+oc login <cluster>
+make setup-openshift
+make oc-status
+```
+
+### 6. Commit Your Changes
+
+Write clear commit messages in imperative mood:
+
+```bash
+# Good
+git commit -m "fix: Increase MongoDB connection timeout to 30s
+
+The default 10s timeout was insufficient for slow cluster starts.
+Fixes #42"
+
+# Bad
+git commit -m "fixed stuff"
+```
+
+Use conventional commit prefixes:
+- `fix:` - Bug fixes
+- `feat:` - New features
+- `docs:` - Documentation
+- `refactor:` - Code changes that don't fix bugs or add features
+- `chore:` - Maintenance tasks
+
+### 7. Push and Create a Pull Request
+
+```bash
+git push origin fix/mongodb-connection-timeout
+```
+
+Then create a Pull Request via GitHub:
+
+- Reference the issue: "Fixes #42" or "Closes #42"
+- Describe what changed and why
+- Include testing steps if not obvious
+- Add screenshots for UI-related changes
+
+### 8. Address Review Feedback
+
+Maintainers will review your PR. Be responsive to feedback and push additional commits as needed. Once approved, a maintainer will merge your PR.
+
+## Code of Conduct
+
+Be respectful and constructive in all interactions. We're building something meaningful together.
+
+## Questions?
+
+If you're unsure about anything, ask in your issue or reach out to the maintainers. We're happy to help guide your contribution.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with fork-and-PR workflow
- Add `AGENTS.md` for AI coding assistants
- Update `CLAUDE.md` to reference the contributing guide

## Details

**CONTRIBUTING.md** establishes the contribution workflow:
1. Open an issue first
2. Fork the repository
3. Create a feature branch
4. Make changes and test
5. Submit PR referencing the issue

**AGENTS.md** provides context for AI tools (Copilot, Cursor, Cody, etc.) that may not read CLAUDE.md.

**CLAUDE.md** updated with a Contributing section that points to the guide.

## Test Plan

- [x] Followed the guide to create this PR (dogfooding)
- [x] Issue created first (#34)
- [x] Branch naming follows convention (`docs/`)
- [x] Commit message uses conventional format

## Notes from Dogfooding

The guide is clear for the happy path. One potential improvement: the commit message example shows `Fixes #42` at the end, but some contributors might wonder if it goes in the subject line or body. The current example is sufficient but could be more explicit.

Closes #34