### PR TITLE
feat: add feedback feature documentation and project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,9 @@ __marimo__/
 # Cloned application repositories
 gng-backend/
 gng-web/
+
+# Claude Code
+.claude/
+
+# Playwright MCP
+.playwright-mcp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,13 @@ make oc-logs-minio
 make clean-openshift      # Delete namespace + local config files
 make cleanup-jobs         # Remove completed OpenShift jobs
 
+# Testing
+make test-all             # Full test suite (Docker Compose + backend + E2E)
+make test-services-up     # Start test environment (MongoDB, MinIO, backend, frontend)
+make test-services-down   # Stop test environment
+make test-backend         # Run backend pytest tests
+make test-e2e             # Run Playwright E2E tests
+
 # Optional
 make deploy-whisper MODEL=base   # Deploy Whisper ASR (tiny/base/small/medium/large-v3)
 ```
@@ -79,6 +86,8 @@ Most OpenShift commands auto-detect the namespace from `.openshift-config`. Over
 - `infra/` — Kubernetes/OpenShift YAML manifests organized by service (`mongodb/`, `minio/`, `backend/`, `frontend/`, `whisper/`)
 - `env-templates/` — Template `.env` files for backend and frontend configuration
 - `docs/ADMIN_SETUP.md` — Admin-only cluster preparation (namespace creation, image pre-import)
+- `docs/TESTING.md` — Testing strategy, running tests, CI pipeline
+- `docker-compose.test.yml` — Docker Compose for test environment (MongoDB, MinIO, backend, frontend)
 - `INFRA.md` — Detailed infrastructure and deployment reference
 
 ## Key Configuration Files (gitignored)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A deployment and development toolkit for the **Griot & Grits** project (AI-powered minority history preservation). This repo contains no application source code — it orchestrates two external repos:
+
+- **Frontend** (`gng-web`): Next.js React app, cloned to `~/gng-web` (local) or `./gng-web` (OpenShift)
+- **Backend** (`gng-backend`): FastAPI Python app, cloned to `~/gng-backend` (local) or `./gng-backend` (OpenShift)
+
+Both are cloned from `https://github.com/griot-and-grits/`.
+
+## Architecture
+
+```
+Frontend (Next.js :3000) → Backend (FastAPI :8000)
+                                ↓
+                    ┌───────────┼───────────┐
+                    MongoDB    MinIO     Whisper (optional)
+                    :27017     :9000     (transcription)
+```
+
+- **MongoDB**: Document database (credentials: admin/gngdevpass12, database: gngdb)
+- **MinIO**: S3-compatible object storage (credentials: minioadmin/minioadmin, bucket: artifacts)
+- **Container runtime**: Podman (preferred, rootless) or Docker, stored in `.container-runtime`
+
+## Common Commands
+
+All orchestration goes through the Makefile:
+
+```bash
+# Local development
+make setup-local          # One-time: clones repos, checks deps, installs Podman
+make dev                  # Start full stack (MongoDB + MinIO + backend + frontend)
+make dev-backend          # Backend only (uvicorn --reload on :8000)
+make dev-frontend         # Frontend only (next dev on :3000)
+make start-services       # Start MongoDB and MinIO containers
+make stop-services        # Stop containers
+make status               # Check running services
+make clean-local          # Remove containers (keep data)
+make clean-local-all      # Remove containers and data volumes
+
+# OpenShift deployment
+make setup-openshift USERNAME=<name>           # Create namespace gng-<name> with services
+make setup-openshift-with-code USERNAME=<name> # Above + deploy apps with hot-reload
+make deploy-services      # Deploy MongoDB + MinIO (auto-detects namespace)
+make deploy-code          # Deploy backend + frontend with hot-reload
+make info                 # Show URLs, credentials, connection details
+make oc-status            # View all OpenShift resources
+
+# Code sync to OpenShift
+make sync                 # Manual sync (both apps)
+make sync-backend         # Sync backend only
+make watch-backend        # Continuous background sync (instant + every 2s)
+make watch-backend-stop   # Stop background sync
+make watch-start          # Auto-sync watcher (both apps)
+make watch-stop-all       # Stop all watchers
+
+# Logs
+make oc-logs-backend
+make oc-logs-frontend
+make oc-logs-mongodb
+make oc-logs-minio
+
+# Cleanup
+make clean-openshift      # Delete namespace + local config files
+make cleanup-jobs         # Remove completed OpenShift jobs
+
+# Optional
+make deploy-whisper MODEL=base   # Deploy Whisper ASR (tiny/base/small/medium/large-v3)
+```
+
+Most OpenShift commands auto-detect the namespace from `.openshift-config`. Override with `NAMESPACE=gng-custom`.
+
+## Repository Structure
+
+- `scripts/` — Bash scripts that implement all Makefile targets (setup, deploy, sync, watch, clean)
+- `infra/` — Kubernetes/OpenShift YAML manifests organized by service (`mongodb/`, `minio/`, `backend/`, `frontend/`, `whisper/`)
+- `env-templates/` — Template `.env` files for backend and frontend configuration
+- `docs/ADMIN_SETUP.md` — Admin-only cluster preparation (namespace creation, image pre-import)
+- `INFRA.md` — Detailed infrastructure and deployment reference
+
+## Key Configuration Files (gitignored)
+
+- `.openshift-config` — Stores NAMESPACE and USERNAME for auto-detection
+- `.env.openshift` — OpenShift environment connection details
+- `.container-runtime` — `podman` or `docker`
+- `.watch-backend.pid/.log` — Background watcher state
+
+## Working with Scripts
+
+All scripts are bash. They use color-coded output, auto-detect the container runtime, and handle error cases. When modifying scripts:
+
+- The container runtime (podman/docker) is read from `.container-runtime` or auto-detected
+- OpenShift scripts expect `oc` CLI to be available and the user to be logged in
+- Scripts use `oc rsync` for code sync, excluding `.git`, `__pycache__`, `node_modules`, `.venv`
+- Backend runs via `uvicorn app.server:app --reload` (Python 3.11)
+- Frontend runs via `npm run dev` (Node.js 20)
+
+## OpenShift Deployment Model
+
+Pods clone application repos at startup via git, then run in dev mode with hot-reload. Code changes are synced to running pods using `oc rsync`, which triggers uvicorn/Next.js reload. This is not a traditional build-and-deploy pipeline — it's designed for rapid hackathon iteration.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,27 @@ Key variables:
 
 See `env-templates/` for full examples.
 
+## Testing
+
+Run the full test suite (backend API tests + Playwright E2E) with a single command:
+
+```bash
+make test-all        # Starts Docker services, runs all tests, stops services
+```
+
+Individual test commands:
+
+```bash
+make test-services-up    # Start test environment (MongoDB, MinIO, backend, frontend)
+make test-backend        # Run backend pytest suite
+make test-e2e            # Run Playwright E2E tests
+make test-services-down  # Stop test environment
+```
+
+See [docs/TESTING.md](docs/TESTING.md) for detailed documentation.
+
+---
+
 ## Advanced
 
 ### Deploy Whisper ASR (Optional)

--- a/backlog/feedback-feature.md
+++ b/backlog/feedback-feature.md
@@ -33,7 +33,7 @@ Full-stack user feedback mechanism allowing public users to report issues on Gri
 - [x] `lib/admin/status.ts` — Modified: added FEEDBACK_STATUS_STYLES, FEEDBACK_TYPE_STYLES, getFeedbackStatusStyle, getFeedbackTypeStyle
 - [x] `components/admin/shared/feedback-status-badge.tsx` — Created: status badge component
 - [x] `components/admin/shared/feedback-type-badge.tsx` — Created: type badge component
-- [x] `components/admin/feedback/feedback-table.tsx` — Created: admin feedback table with filters, expandable rows, inline status update
+- [x] `components/admin/feedback/feedback-table.tsx` — Created: admin feedback table with stat cards, search, type/status filters, artifact links, detail dialog with admin notes editing, and pagination
 - [x] `app/admin/feedback/page.tsx` — Created: admin page route
 - [x] `components/admin/shell/admin-shell.tsx` — Modified: added Feedback nav item with Flag icon
 - [x] `app/admin/page.tsx` — Modified: added "Review Feedback" quick action card
@@ -51,6 +51,6 @@ Full-stack user feedback mechanism allowing public users to report issues on Gri
 
 3. **Single modal instance pattern**: One `<FeedbackModal>` instance in Collections with dynamic context via state, rather than one per chat message or video card.
 
-4. **Inline status updates**: Admin feedback table uses an inline `<select>` dropdown for status changes, triggering a PATCH mutation immediately on change, rather than requiring a separate edit page.
+4. **Detail dialog for actions**: Admin feedback table uses a "View" button to open a detail dialog where admins can review full context, edit admin notes, and change status via a "Save Changes" action, rather than inline status dropdowns.
 
 5. **FeedbackService always available**: Unlike CollectionService (conditional on Globus), FeedbackService is always initialized since it only depends on MongoDB.

--- a/backlog/feedback-feature.md
+++ b/backlog/feedback-feature.md
@@ -1,0 +1,56 @@
+# Feedback Feature
+
+## Description
+
+Full-stack user feedback mechanism allowing public users to report issues on Griot AI responses and video/artifact content. Admins can view, filter, and manage feedback from the admin dashboard.
+
+## Implementation Checklist
+
+### Backend (gng-backend)
+
+- [x] `app/models/feedback.py` — Created: FeedbackType, FeedbackStatus, Feedback, FeedbackCreateRequest, FeedbackStatusUpdateRequest
+- [x] `app/models/__init__.py` — Modified: added feedback model exports
+- [x] `app/services/db.py` — Modified: added feedback indexes and CRUD methods (insert_feedback, get_feedback, update_feedback, list_feedback, count_feedback)
+- [x] `app/services/feedback_service.py` — Created: FeedbackService with create, update_status, get, list methods
+- [x] `app/factory.py` — Modified: wired FeedbackService (always available, no conditional)
+- [x] `app/api/feedback.py` — Created: FastAPI router with POST, GET, GET/:id, PATCH/:id/status
+- [x] `app/api/__init__.py` — Modified: exported feedback_router
+- [x] `app/server.py` — Modified: included feedback router, added to root endpoint
+
+### Frontend API Layer (gng-web)
+
+- [x] `lib/admin/types.ts` — Modified: added FeedbackType, FeedbackStatus, Feedback, FeedbackCreateRequest, FeedbackStatusUpdateRequest, FeedbackListResponse
+- [x] `lib/admin/apis/feedback.ts` — Created: feedbackApi with create, getById, updateStatus, list
+- [x] `lib/admin/apis/index.ts` — Modified: exported feedback API
+
+### Frontend Public (gng-web)
+
+- [x] `components/feedback/feedback-modal.tsx` — Created: feedback submission dialog with form, success/error states
+- [x] `components/collections.tsx` — Modified: added Flag icon import, FeedbackModal import, feedback state/helpers, "Report issue" on chat messages, "Report Issue" on video cards, modal render
+
+### Frontend Admin (gng-web)
+
+- [x] `lib/admin/status.ts` — Modified: added FEEDBACK_STATUS_STYLES, FEEDBACK_TYPE_STYLES, getFeedbackStatusStyle, getFeedbackTypeStyle
+- [x] `components/admin/shared/feedback-status-badge.tsx` — Created: status badge component
+- [x] `components/admin/shared/feedback-type-badge.tsx` — Created: type badge component
+- [x] `components/admin/feedback/feedback-table.tsx` — Created: admin feedback table with filters, expandable rows, inline status update
+- [x] `app/admin/feedback/page.tsx` — Created: admin page route
+- [x] `components/admin/shell/admin-shell.tsx` — Modified: added Feedback nav item with Flag icon
+- [x] `app/admin/page.tsx` — Modified: added "Review Feedback" quick action card
+
+### Documentation (rh-hackathon)
+
+- [x] `docs/FEEDBACK.md` — Created: feature documentation
+- [x] `backlog/feedback-feature.md` — Created: this file
+
+## Design Decisions
+
+1. **No authentication for submission**: The POST /feedback/ endpoint is public so any visitor can report issues without needing to sign in.
+
+2. **Plain axios on public page**: The public Collections page has no QueryClientProvider, so the FeedbackModal uses plain axios via `feedbackApi.create()` with `useState` for loading/error/success state instead of `useMutation`.
+
+3. **Single modal instance pattern**: One `<FeedbackModal>` instance in Collections with dynamic context via state, rather than one per chat message or video card.
+
+4. **Inline status updates**: Admin feedback table uses an inline `<select>` dropdown for status changes, triggering a PATCH mutation immediately on change, rather than requiring a separate edit page.
+
+5. **FeedbackService always available**: Unlike CollectionService (conditional on Globus), FeedbackService is always initialized since it only depends on MongoDB.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,99 @@
+# Docker Compose for E2E testing
+# Spins up MongoDB, MinIO, backend, and frontend for integration/E2E tests.
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml up -d --build --wait
+#   docker compose -f docker-compose.test.yml down -v
+#
+# MongoDB and MinIO are only accessible within the Docker network.
+# Backend (:8000) and frontend (:3000) are exposed to the host.
+
+services:
+  mongodb:
+    image: mongo:7
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: admin
+      MONGO_INITDB_ROOT_PASSWORD: gngdevpass12
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  minio:
+    image: minio/minio
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 minioadmin minioadmin &&
+        mc mb --ignore-existing local/artifacts &&
+        echo 'Bucket ready'
+      "
+
+  backend:
+    build:
+      context: ${BACKEND_PATH:-./gng-backend}
+      dockerfile: Dockerfile
+    ports:
+      - "${BACKEND_PORT:-8000}:8000"
+    environment:
+      DB_URI: mongodb://admin:gngdevpass12@mongodb:27017/
+      DB_NAME: gngdb_test
+      STORAGE_ENDPOINT: minio:9000
+      STORAGE_ACCESS_KEY: minioadmin
+      STORAGE_SECRET_KEY: minioadmin
+      STORAGE_BUCKET: artifacts
+      STORAGE_SECURE: "false"
+      PROCESSING_ENABLE_TRANSCRIPTION: "false"
+      PROCESSING_ENABLE_METADATA_EXTRACTION: "false"
+      GLOBUS_ENABLED: "false"
+      CORS_ALLOWED_ORIGINS: "http://localhost:3000,http://localhost:3001,http://frontend:3000"
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+      start_period: 15s
+
+  frontend:
+    build:
+      context: ${FRONTEND_PATH:-./gng-web}
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_ADMIN_API_BASE_URL: http://localhost:${BACKEND_PORT:-8000}
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    environment:
+      ADMIN_AUTH_DISABLED: "true"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://0.0.0.0:3000"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+      start_period: 15s

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -101,9 +101,12 @@ Required: `description`, `feedback_type`. All other fields are optional.
 ### Admin Dashboard
 
 1. Navigate to `/admin/feedback` or click "Review Feedback" on the dashboard.
-2. Filter by status and/or feedback type using the dropdown filters.
-3. Click a row to expand and see full details (description, context, submitter info).
-4. Change status via the inline dropdown in the Actions column.
+2. View status distribution at a glance via the summary stat cards (New, Reviewed, Resolved, Dismissed). Click a card to filter by that status.
+3. Search feedback by description, reporter name/email, or artifact title using the search bar. Filter by type using the type dropdown.
+4. If a feedback item is linked to an artifact, click the link icon next to the description to go directly to that artifact.
+5. Click "View" on a row to open the detail dialog with full context (description, Griot response, reporter info, related artifact).
+6. In the detail dialog, update the status, add admin notes, and save changes.
+7. Navigate large result sets using the pagination controls (25 items per page).
 
 ## MongoDB
 

--- a/docs/FEEDBACK.md
+++ b/docs/FEEDBACK.md
@@ -1,0 +1,111 @@
+# User Feedback Feature
+
+## Overview
+
+The feedback feature allows users to report issues with Griot AI responses, video content, and transcript accuracy directly from the public Collections page. Admins can view, filter, and manage feedback from the admin dashboard.
+
+## API Endpoints
+
+All endpoints are served from the backend at `/feedback`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/feedback/` | Submit feedback (public, no auth) |
+| `GET` | `/feedback/` | List feedback with optional filters |
+| `GET` | `/feedback/{feedback_id}` | Get single feedback by ID |
+| `PATCH` | `/feedback/{feedback_id}/status` | Update status and admin notes |
+
+### Query Parameters (GET /feedback/)
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `status` | string | Filter by status: `new`, `reviewed`, `resolved`, `dismissed` |
+| `feedback_type` | string | Filter by type: `transcript_accuracy`, `griot_response`, `content_issue`, `other` |
+| `limit` | int | Max results (1-100, default 50) |
+| `skip` | int | Pagination offset (default 0) |
+
+### POST /feedback/ Request Body
+
+```json
+{
+  "description": "The response mentioned incorrect dates",
+  "feedback_type": "griot_response",
+  "artifact_id": "video-123",
+  "artifact_title": "Interview with Jane Doe",
+  "chat_user_message": "Tell me about the 1960s movement",
+  "chat_assistant_message": "The movement began in 1975...",
+  "submitter_name": "John Smith",
+  "submitter_email": "john@example.com"
+}
+```
+
+Required: `description`, `feedback_type`. All other fields are optional.
+
+### PATCH /feedback/{id}/status Request Body
+
+```json
+{
+  "status": "reviewed",
+  "admin_notes": "Confirmed inaccuracy, will update knowledge base"
+}
+```
+
+## Data Model
+
+### FeedbackType
+
+| Value | Description |
+|-------|-------------|
+| `transcript_accuracy` | Issues with video transcription |
+| `griot_response` | Problems with AI-generated responses |
+| `content_issue` | Issues with video or artifact content |
+| `other` | General feedback |
+
+### FeedbackStatus
+
+| Value | Description |
+|-------|-------------|
+| `new` | Just submitted, not yet reviewed |
+| `reviewed` | Admin has seen it |
+| `resolved` | Issue has been addressed |
+| `dismissed` | Determined not actionable |
+
+### Feedback Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `feedback_id` | string | Unique ID (e.g., `fb_a1b2c3d4e5f6`) |
+| `description` | string | User's description of the issue |
+| `feedback_type` | FeedbackType | Category of feedback |
+| `status` | FeedbackStatus | Current review status |
+| `artifact_id` | string? | Related video/artifact ID |
+| `artifact_title` | string? | Related video/artifact title |
+| `chat_user_message` | string? | User's chat message (for Griot feedback) |
+| `chat_assistant_message` | string? | Griot's response (for Griot feedback) |
+| `submitter_name` | string? | Optional submitter name |
+| `submitter_email` | string? | Optional submitter email |
+| `admin_notes` | string? | Notes added by admin |
+| `created_at` | datetime | Submission timestamp |
+| `updated_at` | datetime? | Last update timestamp |
+
+## User Flow
+
+### Public-facing (Collections page)
+
+1. **Griot AI responses**: After the Griot responds to a question, a "Report issue" link appears below each assistant message. Clicking it opens the feedback modal pre-filled with the Griot response context.
+
+2. **Video cards**: Each video card in the collection grid has a "Report Issue" button. Clicking it opens the feedback modal pre-filled with the video title.
+
+3. **Modal**: Users select an issue type, describe the problem, and optionally provide their name and email. On submission, a success banner confirms the report was received.
+
+### Admin Dashboard
+
+1. Navigate to `/admin/feedback` or click "Review Feedback" on the dashboard.
+2. Filter by status and/or feedback type using the dropdown filters.
+3. Click a row to expand and see full details (description, context, submitter info).
+4. Change status via the inline dropdown in the Actions column.
+
+## MongoDB
+
+- **Collection name**: `feedback`
+- **Indexes**: `feedback_id` (unique), `status`, `feedback_type`, `artifact_id`, `created_at`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,207 @@
+# Testing Guide
+
+Automated E2E and API tests for the Griot & Grits project.
+
+## Quick Start
+
+```bash
+# Run everything (starts Docker services, runs backend + E2E tests, stops services)
+make test-all
+```
+
+## Overview
+
+| Layer | Tool | Location | What it tests |
+|-------|------|----------|---------------|
+| Backend API | pytest + httpx | `gng-backend/tests/` | FastAPI endpoints (health, artifacts, feedback) |
+| E2E / UI | Playwright | `gng-web/tests/e2e/` | Upload, artifact status, search, feedback flows |
+| Infrastructure | Docker Compose | `rh-hackathon/docker-compose.test.yml` | MongoDB, MinIO, backend, frontend as containers |
+
+## Docker Compose Test Environment
+
+The `docker-compose.test.yml` file spins up 5 services:
+
+| Service | Image | Port | Purpose |
+|---------|-------|------|---------|
+| mongodb | mongo:7 | 27017 | Document database |
+| minio | minio/minio | 9000 | S3-compatible object storage |
+| minio-init | minio/mc | — | Creates the `artifacts` bucket, then exits |
+| backend | Built from `gng-backend/` | 8000 | FastAPI application |
+| frontend | Built from `gng-web/` | 3000 | Next.js application |
+
+### Start / Stop
+
+```bash
+make test-services-up    # Build and start all containers (waits for healthy)
+make test-services-down  # Stop containers and remove volumes
+```
+
+### Key environment settings
+
+- `DB_NAME=gngdb_test` — isolated test database
+- `PROCESSING_ENABLE_TRANSCRIPTION=false` — skips Whisper (artifacts go straight to READY)
+- `PROCESSING_ENABLE_METADATA_EXTRACTION=false` — skips metadata extraction
+- `ADMIN_AUTH_DISABLED=true` — disables NextAuth on the frontend
+- `GLOBUS_ENABLED=false` — disables Globus archive integration
+
+## Backend API Tests (pytest)
+
+Located in `gng-backend/tests/`:
+
+```
+tests/
+├── conftest.py                  # httpx AsyncClient fixture
+└── test_api/
+    ├── test_health.py           # GET /health, GET /
+    ├── test_artifacts.py        # POST /artifacts/ingest, GET status, list
+    └── test_feedback.py         # POST /feedback/, GET, PATCH status
+```
+
+### Running
+
+```bash
+# With Docker Compose services running:
+cd ~/gng-backend
+python -m pytest tests/ -v
+
+# Or via Makefile:
+make test-backend
+```
+
+The tests use `httpx.AsyncClient` with `ASGITransport` to call the FastAPI app directly. They require MongoDB and MinIO to be available (provided by Docker Compose).
+
+## E2E Tests (Playwright)
+
+Located in `gng-web/tests/e2e/`:
+
+```
+tests/e2e/
+├── helpers/
+│   ├── api-client.ts      # Backend API wrapper for seeding data
+│   ├── test-data.ts        # Unique metadata/file generators
+│   └── setup.ts            # Global setup: waits for services
+├── home.spec.ts             # Homepage smoke tests
+├── admin.spec.ts            # Admin sign-in page
+├── collection.spec.ts       # Public collection page
+├── upload.spec.ts           # Artifact upload via UI form
+├── artifact-status.spec.ts  # Artifact status verification
+├── search.spec.ts           # Artifact list/search
+└── feedback.spec.ts         # Feedback list and filters
+```
+
+### Running
+
+```bash
+# With Docker Compose services running:
+cd ~/gng-web
+npx playwright test              # Headless
+npx playwright test --headed     # With browser visible
+npx playwright test --ui         # Interactive UI mode
+npx playwright test --debug      # Step-by-step debugger
+
+# View HTML report after a run:
+npx playwright show-report
+```
+
+### Test descriptions
+
+| File | Tests |
+|------|-------|
+| `upload.spec.ts` | Attaches file, fills metadata form, submits, verifies redirect to artifact detail |
+| `artifact-status.spec.ts` | Seeds artifact via API, checks status is `ready`, visits detail page |
+| `search.spec.ts` | Seeds 3 artifacts, verifies admin artifacts page renders, checks collection page |
+| `feedback.spec.ts` | Seeds feedback via API, verifies feedback table renders, checks filter controls |
+
+## Authentication in Tests
+
+The frontend middleware (`middleware.ts`) checks `ADMIN_AUTH_DISABLED`:
+
+```typescript
+const authDisabled = process.env.ADMIN_AUTH_DISABLED === 'true';
+```
+
+When `ADMIN_AUTH_DISABLED=true`, all `/admin/*` routes are accessible without authentication. This is set automatically in the Docker Compose test environment.
+
+## Mocking Transcription
+
+Whisper transcription is disabled in the test environment via:
+
+- `PROCESSING_ENABLE_TRANSCRIPTION=false`
+- `PROCESSING_ENABLE_METADATA_EXTRACTION=false`
+
+This means artifacts go straight from `PROCESSING` to `READY` status after ingestion, without waiting for any background processing.
+
+## CI Pipeline
+
+The GitHub Actions workflow (`.github/workflows/e2e.yml` in gng-web) runs on:
+
+- Pull requests to `main` or `dev`
+- Pushes to `main`
+
+### What it does
+
+1. Checks out `gng-web`, `gng-backend`, and `rh-hackathon`
+2. Starts all services via `docker compose -f rh-hackathon/docker-compose.test.yml up`
+3. Installs Node.js dependencies and Playwright
+4. Runs `npx playwright test`
+5. Uploads `playwright-report/` as a GitHub Actions artifact
+6. Tears down Docker Compose
+
+### Branch protection
+
+To block PRs on test failure, enable branch protection on `main`:
+
+1. Go to **Settings > Branches > Branch protection rules**
+2. Add rule for `main`
+3. Check **Require status checks to pass before merging**
+4. Select the **E2E Tests / e2e** check
+
+## Adding New Tests
+
+### New Playwright test
+
+1. Create `tests/e2e/your-feature.spec.ts`
+2. Use helpers from `helpers/api-client.ts` to seed data
+3. Use `helpers/test-data.ts` for unique metadata
+4. Run `npx playwright test your-feature` to verify
+
+### New pytest test
+
+1. Create `tests/test_api/test_your_feature.py`
+2. Use the `client` fixture from `conftest.py`
+3. Run `python -m pytest tests/test_api/test_your_feature.py -v`
+
+## Troubleshooting
+
+### Services won't start
+
+```bash
+# Check container logs
+docker compose -f docker-compose.test.yml logs backend
+docker compose -f docker-compose.test.yml logs frontend
+
+# Rebuild from scratch
+make test-services-down
+make test-services-up
+```
+
+### Backend tests fail with connection errors
+
+Ensure Docker Compose services are running and healthy:
+
+```bash
+docker compose -f docker-compose.test.yml ps
+curl http://localhost:8000/health
+```
+
+### Playwright tests time out
+
+1. Check that the frontend is accessible: `curl http://localhost:3000`
+2. Check that auth is disabled: the Docker Compose sets `ADMIN_AUTH_DISABLED=true`
+3. Run with `--debug` flag to step through: `npx playwright test --debug`
+
+### CI fails but local passes
+
+- CI uses `reuseExistingServer: true` (services started by Docker Compose)
+- Locally, Playwright starts `npm run dev` itself
+- Ensure `BACKEND_URL` and `CI` env vars are set when mimicking CI locally

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -132,12 +132,12 @@ else
 fi
 
 # Check Python
-if command -v python3 &> /dev/null; then
-    PYTHON_VERSION=$(python3 --version)
+if command -v python &> /dev/null; then
+    PYTHON_VERSION=$(python --version)
     print_success "Python: $PYTHON_VERSION"
 else
-    print_error "Python3: not found"
-    MISSING_DEPS+=("python3")
+    print_error "Python: not found"
+    MISSING_DEPS+=("python")
 fi
 
 # Check uv (preferred) or pip


### PR DESCRIPTION
## Summary
- Add Docker Compose test environment (`docker-compose.test.yml`) with MongoDB, MinIO, backend, and frontend services for CI and local E2E testing
- Add Makefile test targets: `test-all`, `test-services-up/down`, `test-backend`, `test-e2e`
- Add comprehensive testing documentation (`docs/TESTING.md`)
- Add feedback feature documentation (`docs/FEEDBACK.md`, `backlog/feedback-feature.md`)
- Add `CLAUDE.md` project instructions and minor setup script fixes
- Update `README.md` with testing section
- Update `.gitignore` for `.claude/` and `.playwright-mcp/`

Closes #11, closes #17

## Test plan
- [ ] `make test-services-up` starts all 5 Docker containers and they reach healthy state
- [ ] `make test-backend` runs 14 backend pytest tests (health, artifacts, feedback)
- [ ] `make test-e2e` runs 13 Playwright E2E tests (upload, search, feedback, admin)
- [ ] `make test-all` runs the full suite end-to-end
- [ ] `make test-services-down` cleans up containers and volumes
- [ ] Verify `docs/TESTING.md` documents the full testing strategy
- [ ] Verify `docs/FEEDBACK.md` accurately describes the feedback API and admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)